### PR TITLE
Fix cloud run settings

### DIFF
--- a/demo/demo/settings/production.py
+++ b/demo/demo/settings/production.py
@@ -7,12 +7,10 @@ from .base import *  # noqa
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = [
-    "127.0.0.1",
-    "localhost",
-    "https://semantic-admin-n673kvbdna-an.a.run.app/",
-    "semantic-admin.com",
-]
+ALLOWED_HOSTS = ["semantic-admin.com"]
+
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 sentry_sdk.init(
     dsn=config("SENTRY_DSN"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-semantic-admin"
-version = "0.2.6"
+version = "0.2.7"
 description = "Django Semantic UI Admin theme"
 authors = ["Alex <globophobe@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Something had changed in cloud run, affecting https proxy. Fix as described in https://ubuntu.com/blog/django-behind-a-proxy-fixing-absolute-urls

Closes https://github.com/globophobe/django-semantic-admin/issues/23