### PR TITLE
django 6.0 deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ class DemoModel(models.Model):
     @property
     def semantic_autocomplete(self):
         html = self.get_img()
-        return format_html(html)
+        return mark_safe(html)
 ```
 
 3. Optional integration with [django-import-export](https://github.com/django-import-export/django-import-export):

--- a/demo/demo/forms.py
+++ b/demo/demo/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.admin.forms import AdminAuthenticationForm
 from django.contrib.auth.forms import UsernameField
-from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.views.decorators.debug import sensitive_variables
 
 try:
@@ -15,7 +15,7 @@ class LoginForm(AdminAuthenticationForm):
 
     error_messages = {
         **AdminAuthenticationForm.error_messages,
-        "invalid_login": format_html(
+        "invalid_login": mark_safe(
             _("Please enter username <i>admin</i> and password <i>semantic</i>.")
         ),
     }

--- a/demo/demo_app/admin.py
+++ b/demo/demo_app/admin.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import Group, User
 from django.db.models import Count, QuerySet
 from django.http import HttpRequest
 from django.urls import reverse
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from taggit.models import Tag
 
@@ -45,7 +44,7 @@ def html5_picture(obj: Picture, css: str = "") -> str:
     name = str(obj)
     img = obj.get_img(css=css)
     html = f"{img}<em>{name}</em>"
-    return format_html(mark_safe(html))
+    return mark_safe(html)
 
 
 class PictureStackedInline(StackedInline):
@@ -107,7 +106,7 @@ class PersonAdmin(ModelAdmin):
             a = f"<a href={url}>{friend.name}</a>"
             friends.append(a)
         html = ", ".join(friends)
-        return format_html(mark_safe(html))
+        return mark_safe(html)
 
     list_friends.short_description = _("friends").capitalize()  # type: ignore
 
@@ -122,7 +121,7 @@ class PersonAdmin(ModelAdmin):
             a = f"<a href={url}>{img}<em>{name}</em></a>"
             favorites.append(a)
         html = "".join(favorites)
-        return format_html(mark_safe(html))
+        return mark_safe(html)
 
     list_favorites.short_description = _("favorites").capitalize()  # type: ignore
 
@@ -195,7 +194,7 @@ class PictureAdmin(ModelAdmin):
         """Person change link."""
         url = reverse("admin:demo_app_person_change", args=(obj.pk,))
         a = f"<a href={url}>{obj.person.name}</a>"
-        return format_html(mark_safe(a))
+        return mark_safe(a)
 
     person_changelink.short_description = _("person").capitalize()  # type: ignore
     person_changelink.admin_order_field = "person"  # type: ignore

--- a/demo/demo_app/models.py
+++ b/demo/demo_app/models.py
@@ -3,7 +3,7 @@ import os
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from taggit.managers import TaggableManager
 
 try:
@@ -65,7 +65,7 @@ class Picture(models.Model):
         name = str(self)
         img = self.get_img(css="small rounded right spaced")
         html = f"<p>{img}{name}</p>"
-        return format_html(html)
+        return mark_safe(html)
 
     def __str__(self):
         return ", ".join((tag.name for tag in self.tags.all())) if self.pk else ""
@@ -91,7 +91,7 @@ class Favorite(models.Model):
     )
 
     def __str__(self):
-        return format_html('<i class="large red heart icon"></i>')
+        return mark_safe('<i class="large red heart icon"></i>')
 
     class Meta:
         verbose_name = _("favorite")

--- a/docs/awesome.md
+++ b/docs/awesome.md
@@ -30,7 +30,7 @@ class DemoModel(models.Model):
     @property
     def semantic_autocomplete(self):
         html = self.get_img()
-        return format_html(html)
+        return mark_safe(html)
 ```
 
 <ol start="3"><li>Optional integration with <a href="https://github.com/django-import-export/django-import-export">django-import-export</a>:</li></ol>

--- a/semantic_admin/admin.py
+++ b/semantic_admin/admin.py
@@ -17,7 +17,7 @@ from django.forms.models import (
     modelformset_factory,
 )
 from django.http import HttpRequest, HttpResponse
-from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from semantic_forms.widgets import (
     SemanticCheckboxInput,
     SemanticDateInput,
@@ -285,14 +285,12 @@ class SemanticModelAdmin(SemanticBaseModelAdmin, AwesomeSearchModelAdmin):
         )
         return semantic_checkbox.render(helpers.ACTION_CHECKBOX_NAME, str(obj.pk))
 
-    action_checkbox.short_description = format_html(  # type: ignore
-        format_html(
-            """
-            <div id="action-toggle" class="ui checkbox">
-                <label></label><input id="action-toggle-input" type="checkbox">
-            </div>
-            """
-        )
+    action_checkbox.short_description = mark_safe(  # type: ignore
+        """
+        <div id="action-toggle" class="ui checkbox">
+            <label></label><input id="action-toggle-input" type="checkbox">
+        </div>
+        """
     )
 
     def autocomplete_view(self, request: HttpRequest) -> HttpResponse:

--- a/semantic_admin/templatetags/awesomesearch.py
+++ b/semantic_admin/templatetags/awesomesearch.py
@@ -1,5 +1,4 @@
 from django import forms, template
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 BLANK_LABEL = "<label>&nbsp;</label>"
@@ -142,4 +141,4 @@ def search_fields(context, cl):
         html += format_fields(cl, fields)
     else:
         html = search_field
-    return format_html(mark_safe(html))
+    return mark_safe(html)

--- a/semantic_admin/templatetags/semantic_admin_list.py
+++ b/semantic_admin/templatetags/semantic_admin_list.py
@@ -20,7 +20,7 @@ register = template.Library()
 
 def _semantic_boolean_icon(field_val: str) -> str:
     """Semantic boolean icon."""
-    return format_html(
+    return mark_safe(
         '<i class="%s circle icon"></i>'
         % {True: "green check", False: "red times", None: "gray question"}[field_val]
     )

--- a/semantic_admin/templatetags/semantic_utils.py
+++ b/semantic_admin/templatetags/semantic_utils.py
@@ -262,7 +262,7 @@ def semantic_paginator_number(cl: ChangeList, i: int) -> str:
     DOT = "."
     ELLIPSIS = getattr(cl.paginator, "ELLIPSIS", None)
     if i == DOT or i == ELLIPSIS:
-        return format_html('<span class="item">... </span>')
+        return mark_safe('<span class="item">... </span>')
     elif i == cl.page_num:
         return format_html('<span class="this-page item active">{}</span> ', i)
     else:


### PR DESCRIPTION
Support for calling `format_html()` without passing args or kwargs was:
* deprecated in Django 5.0 (see https://docs.djangoproject.com/en/dev/releases/5.0/)
* removed in Django 6.0 (see https://docs.djangoproject.com/en/dev/releases/6.0/)

This pull request aims to remove this compatibility issue enabling support of latest Django releases.